### PR TITLE
Package rename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,27 +135,9 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-formats</artifactId>
-      <version>${cdap.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-etl-proto</artifactId>
-      <version>${cdap.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
-      <version>${cdap.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-data-pipeline</artifactId>
       <version>${cdap.version}</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -441,7 +423,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <_exportcontents>io.cdap.plugin.*</_exportcontents>
+            <_exportcontents>io.cdap.plugin.dynamo.sink.*</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>

--- a/src/main/java/io/cdap/plugin/dynamo/sink/BatchDynamoDBSink.java
+++ b/src/main/java/io/cdap/plugin/dynamo/sink/BatchDynamoDBSink.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin;
+package io.cdap.plugin.dynamo.sink;
 
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.PrimaryKey;
@@ -34,7 +34,7 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.plugin.common.ReferenceBatchSink;
 import io.cdap.plugin.common.ReferencePluginConfig;
-import io.cdap.plugin.utils.DynamoDBConstants;
+import io.cdap.plugin.dynamo.sink.utils.DynamoDBConstants;
 import org.apache.hadoop.io.NullWritable;
 
 import java.util.HashMap;

--- a/src/main/java/io/cdap/plugin/dynamo/sink/DynamoDBOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/dynamo/sink/DynamoDBOutputFormat.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin;
+package io.cdap.plugin.dynamo.sink;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
@@ -28,8 +28,8 @@ import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.amazonaws.services.dynamodbv2.model.TableStatus;
 import com.google.common.base.Splitter;
-import io.cdap.plugin.utils.DynamoDBConstants;
-import io.cdap.plugin.utils.DynamoDBUtil;
+import io.cdap.plugin.dynamo.sink.utils.DynamoDBConstants;
+import io.cdap.plugin.dynamo.sink.utils.DynamoDBUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;

--- a/src/main/java/io/cdap/plugin/dynamo/sink/DynamoDBRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/dynamo/sink/DynamoDBRecordWriter.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin;
+package io.cdap.plugin.dynamo.sink;
 
 import com.amazonaws.services.dynamodbv2.document.BatchWriteItemOutcome;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
@@ -23,8 +23,8 @@ import com.amazonaws.services.dynamodbv2.document.internal.InternalUtils;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
-import io.cdap.plugin.utils.DynamoDBConstants;
-import io.cdap.plugin.utils.DynamoDBUtil;
+import io.cdap.plugin.dynamo.sink.utils.DynamoDBConstants;
+import io.cdap.plugin.dynamo.sink.utils.DynamoDBUtil;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;

--- a/src/main/java/io/cdap/plugin/dynamo/sink/NoOpOutputCommitter.java
+++ b/src/main/java/io/cdap/plugin/dynamo/sink/NoOpOutputCommitter.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin;
+package io.cdap.plugin.dynamo.sink;
 
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;

--- a/src/main/java/io/cdap/plugin/dynamo/sink/utils/DynamoDBConstants.java
+++ b/src/main/java/io/cdap/plugin/dynamo/sink/utils/DynamoDBConstants.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin.utils;
+package io.cdap.plugin.dynamo.sink.utils;
 
 /**
  * Contains constants used for the Hadoop to DynamoDB connection.

--- a/src/main/java/io/cdap/plugin/dynamo/sink/utils/DynamoDBUtil.java
+++ b/src/main/java/io/cdap/plugin/dynamo/sink/utils/DynamoDBUtil.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin.utils;
+package io.cdap.plugin.dynamo.sink.utils;
 
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.RegionUtils;

--- a/src/test/java/io/cdap/plugin/dynamo/sink/DynamoDBBatchSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/dynamo/sink/DynamoDBBatchSinkConfigTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin;
+package io.cdap.plugin.dynamo.sink;
 
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import org.junit.Assert;


### PR DESCRIPTION
To avoid conflicts with exporting the same packages in plugins renamed package from io.cdap.plugin to io.cdap.plugin.dynamo.sink
In scope of this PR:
* renamed packages to io.cdap.plugin.dynamo.sink
* removed unnecessary dependencies (cdap-formats, cdap-etl-proto, cdap-etl-batch)